### PR TITLE
去除框架的ShutdownHook功能，在kill pid应用的时候，会触发勾子中的shutdown方法，导致框架将所有模块都卸载，这时候…

### DIFF
--- a/simulator-agent/simulator-agent-core/src/main/java/com/shulie/instrument/simulator/agent/core/CoreLauncher.java
+++ b/simulator-agent/simulator-agent-core/src/main/java/com/shulie/instrument/simulator/agent/core/CoreLauncher.java
@@ -15,7 +15,6 @@
 package com.shulie.instrument.simulator.agent.core;
 
 import com.shulie.instrument.simulator.agent.api.ExternalAPI;
-import com.shulie.instrument.simulator.agent.api.model.CommandPacket;
 import com.shulie.instrument.simulator.agent.core.classloader.ProviderClassLoader;
 import com.shulie.instrument.simulator.agent.core.config.AgentConfigImpl;
 import com.shulie.instrument.simulator.agent.core.config.CoreConfig;
@@ -278,16 +277,17 @@ public class CoreLauncher {
             }
             LOGGER.info("SIMULATOR: agent will start {} {} later... please wait for a while moment.", delay, unit.toString());
         }
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    launcher.shutdown(new StopCommand<CommandPacket>(null));
-                } catch (Throwable e) {
-                    LOGGER.error("SIMULATOR: execute shutdown hook error.", e);
-                }
-            }
-        }));
+        //有这个勾子的话，kill pid杀死应用，会卸载所有的模块，这时流量是还在的，就会漏数
+//        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+//            @Override
+//            public void run() {
+//                try {
+//                    launcher.shutdown(new StopCommand<CommandPacket>(null));
+//                } catch (Throwable e) {
+//                    LOGGER.error("SIMULATOR: execute shutdown hook error.", e);
+//                }
+//            }
+//        }));
     }
 
     private RegisterOptions buildRegisterOptions(AgentConfig agentConfig) {


### PR DESCRIPTION
…应用不会立马停止，这时候还有流量经过会出现漏数