### PR TITLE
fix mock无法生效的bug

### DIFF
--- a/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/interceptor/TraceInterceptor.java
+++ b/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/interceptor/TraceInterceptor.java
@@ -247,8 +247,6 @@ abstract class TraceInterceptor extends BaseInterceptor {
         } finally {
             try {
                 beforeLast(advice);
-            } catch (ProcessControlException e) {
-                // mock功能通过此异常中断后续流程
             } catch (PradarException e) {
                 LOGGER.error("TraceInterceptor beforeLast exec err, class:" + this.getClass().getName(), e);
                 throwable = e;


### PR DESCRIPTION
mock的异常被未处理，导致无法抛出该异常，框架事件机制无法捕捉到mock的异常，导致mock失效