### PR TITLE
rabbitmq 并发条件下影子消费者数量不对的问题修复。

### DIFF
--- a/instrument-modules/user-modules/module-rabbitmq/src/main/java/com/pamirs/attach/plugin/rabbitmq/interceptor/SpringBlockingQueueConsumerDeliveryInterceptor.java
+++ b/instrument-modules/user-modules/module-rabbitmq/src/main/java/com/pamirs/attach/plugin/rabbitmq/interceptor/SpringBlockingQueueConsumerDeliveryInterceptor.java
@@ -215,12 +215,11 @@ public class SpringBlockingQueueConsumerDeliveryInterceptor extends TraceInterce
                         }
                     }
                 }else {
-                    RUNNING_CONTAINER.remove(cacheKey);
+                    // if value not instanceof AbstractMessageListenerContainer，is creating ptContainer.
                 }
             }
         } catch (Throwable e) {
             LOGGER.warn(String.format("[RabbitMQ] ptContainer start fail. cacheKey: %s", cacheKey), e);
-            RUNNING_CONTAINER.remove(cacheKey);
         }
 
         Object[] args = advice.getParameterArray();


### PR DESCRIPTION
因为是并发消费情况下可能会重复注册。所以只能查看日志里面的注册次数
![20220318-115911](https://user-images.githubusercontent.com/39933588/158935001-ecd91f91-7624-4616-8ca3-0c02f0f0f2a2.jpeg)
