### PR TITLE
Feature/lettuce execute support

### DIFF
--- a/instrument-modules/user-modules/module-redis-lettuce/pom.xml
+++ b/instrument-modules/user-modules/module-redis-lettuce/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <module-name>redis-lettuce</module-name>
     </properties>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
 
     <dependencies>
         <dependency>

--- a/instrument-modules/user-modules/module-redis-lettuce/src/main/java/com/pamirs/attach/plugin/lettuce/interceptor/LettuceCommandDispatchClusterTestInterceptor.java
+++ b/instrument-modules/user-modules/module-redis-lettuce/src/main/java/com/pamirs/attach/plugin/lettuce/interceptor/LettuceCommandDispatchClusterTestInterceptor.java
@@ -1,0 +1,115 @@
+package com.pamirs.attach.plugin.lettuce.interceptor;
+
+import com.pamirs.attach.plugin.common.datasource.redisserver.RedisClientMediator;
+import com.pamirs.attach.plugin.dynamic.reflect.Reflect;
+import com.pamirs.attach.plugin.lettuce.LettucePlugin;
+import com.pamirs.pradar.Pradar;
+import com.pamirs.pradar.interceptor.ParametersWrapperInterceptorAdaptor;
+import com.pamirs.pradar.pressurement.ClusterTestUtils;
+import com.pamirs.pradar.pressurement.agent.shared.service.GlobalConfig;
+import com.shulie.instrument.simulator.api.listener.ext.Advice;
+import io.lettuce.core.protocol.ProtocolKeyword;
+
+import java.util.*;
+
+/**
+ * @author jiangjibo
+ * @date 2022/3/18 6:03 下午
+ * @description:
+ */
+public class LettuceCommandDispatchClusterTestInterceptor extends ParametersWrapperInterceptorAdaptor {
+
+    private static Set<String> SupportMethods = new HashSet<String>(256);
+
+    static {
+        for (String method : LettucePlugin.FIRST_ARGS_INCLUDE_METHODS) {
+            SupportMethods.add(method);
+        }
+        SupportMethods.addAll(Arrays.asList("blpop", "brpop", "bzpopmin", "bzpopmax"));
+        SupportMethods.addAll(Arrays.asList("eval", "evalsha"));
+        SupportMethods.addAll(Arrays.asList("bitopAnd", "bitopNot", "bitopOr", "bitopXor", "rpoplpush", "sdiffstore", "sinterstore", "smove", "sunionstore", "pfmerge", "rename", "renamenx"));
+        SupportMethods.addAll(Arrays.asList("sortStore"));
+        SupportMethods.addAll(Arrays.asList("brpoplpush"));
+        SupportMethods.addAll(Arrays.asList("xadd"));
+        SupportMethods.addAll(Arrays.asList("xgroupCreate"));
+        SupportMethods.addAll(Arrays.asList("xgroupSetid"));
+        SupportMethods.addAll(Arrays.asList("xread"));
+        SupportMethods.addAll(Arrays.asList("xreadgroup"));
+        SupportMethods.addAll(Arrays.asList("zinterstore"));
+        SupportMethods.addAll(Arrays.asList("zrange"));
+        SupportMethods.addAll(Arrays.asList("zrangebyscore"));
+        SupportMethods.addAll(Arrays.asList("zrangebyscoreWithScores"));
+        SupportMethods.addAll(Arrays.asList("zrevrange"));
+        SupportMethods.addAll(Arrays.asList("zrevrangeWithScores"));
+        SupportMethods.addAll(Arrays.asList("zrevrangebyscore"));
+        SupportMethods.addAll(Arrays.asList("zrevrangebyscoreWithScores"));
+        SupportMethods.addAll(Arrays.asList("zrevrangebyscoreWithScores"));
+        SupportMethods.addAll(Arrays.asList("zunionstore"));
+        SupportMethods.addAll(Arrays.asList("hscan"));
+        SupportMethods.addAll(Arrays.asList("hgetall"));
+        SupportMethods.addAll(Arrays.asList("hkeys"));
+        SupportMethods.addAll(Arrays.asList("keys"));
+        SupportMethods.addAll(Arrays.asList("hmget"));
+        SupportMethods.addAll(Arrays.asList("hvals"));
+        SupportMethods.addAll(Arrays.asList("lrange"));
+        SupportMethods.addAll(Arrays.asList("mget"));
+        SupportMethods.addAll(Arrays.asList("migrate"));
+
+        Set<String> lowerCases = new HashSet<String>(SupportMethods.size());
+        for (String method : SupportMethods) {
+            lowerCases.add(method.toUpperCase());
+        }
+        SupportMethods = lowerCases;
+    }
+
+    @Override
+    protected Object[] getParameter0(Advice advice) throws Throwable {
+        Object[] args = advice.getParameterArray();
+        ClusterTestUtils.validateClusterTest();
+        if (!Pradar.isClusterTest()) {
+            return args;
+        }
+
+        if (RedisClientMediator.isShadowDb()) {
+            return args;
+        }
+
+        String method = ((ProtocolKeyword) args[0]).name();
+        if (!SupportMethods.contains(method)) {
+            return args;
+        }
+
+        List singularArguments = Reflect.on(args[2]).get("singularArguments");
+        Object keyArgument = singularArguments.get(0);
+
+        byte[] bytes = Reflect.on(keyArgument).get("key");
+        String rawKey = new String(bytes);
+        String processedKey = processKey(rawKey);
+        if (!rawKey.equals(processedKey)) {
+            Reflect.on(keyArgument).set("key",processedKey.getBytes());
+        }
+        return args;
+    }
+
+    private String processKey(String key) {
+        Collection<String> whiteList = GlobalConfig.getInstance().getCacheKeyWhiteList();
+        if (ignore(whiteList, key)) {
+            return key;
+        }
+        String str = key;
+        if (!Pradar.isClusterTestPrefix(str)) {
+            str = Pradar.addClusterTestPrefix(str);
+        }
+        return str;
+    }
+
+    private boolean ignore(Collection<String> whiteList, String key) {
+        //白名单 忽略
+        for (String white : whiteList) {
+            if (key.startsWith(white)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/instrument-modules/user-modules/module-redis-lettuce/src/main/java/com/pamirs/attach/plugin/lettuce/interceptor/LettuceCommandDispatchTraceInterceptor.java
+++ b/instrument-modules/user-modules/module-redis-lettuce/src/main/java/com/pamirs/attach/plugin/lettuce/interceptor/LettuceCommandDispatchTraceInterceptor.java
@@ -1,0 +1,123 @@
+package com.pamirs.attach.plugin.lettuce.interceptor;
+
+import com.pamirs.attach.plugin.dynamic.reflect.Reflect;
+import com.pamirs.attach.plugin.lettuce.LettuceConstants;
+import com.pamirs.attach.plugin.lettuce.destroy.LettuceDestroy;
+import com.pamirs.attach.plugin.lettuce.utils.ParameterUtils;
+import com.pamirs.pradar.Pradar;
+import com.pamirs.pradar.ResultCode;
+import com.pamirs.pradar.interceptor.SpanRecord;
+import com.shulie.instrument.simulator.api.annotation.Destroyable;
+import com.shulie.instrument.simulator.api.listener.ext.Advice;
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.ProtocolKeyword;
+
+import java.lang.reflect.Field;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.util.List;
+
+/**
+ * @author jiangjibo
+ * @date 2022/3/18 4:38 下午
+ * @description:
+ */
+@Destroyable(LettuceDestroy.class)
+public class LettuceCommandDispatchTraceInterceptor extends LettuceMethodInterceptor {
+
+    @Override
+    public SpanRecord beforeTrace(Advice advice) {
+        if (LettuceMethodInterceptor.interceptorApplied.get()) {
+            return null;
+        }
+        Object[] args = advice.getParameterArray();
+        Object target = advice.getTarget();
+        SpanRecord spanRecord = new SpanRecord();
+        appendEndPoint(target, spanRecord);
+        spanRecord.setService(((ProtocolKeyword)args[0]).name());
+        spanRecord.setMethod(getMethodNameExt(args));
+        spanRecord.setRequest(toArgs(args));
+        spanRecord.setMiddlewareName(LettuceConstants.MIDDLEWARE_NAME);
+        return spanRecord;
+    }
+
+    @Override
+    public SpanRecord afterTrace(Advice advice) {
+        if (LettuceMethodInterceptor.interceptorApplied.get()) {
+            return null;
+        }
+        SpanRecord spanRecord = new SpanRecord();
+        spanRecord.setMiddlewareName(LettuceConstants.MIDDLEWARE_NAME);
+        spanRecord.setCallbackMsg(LettuceConstants.PLUGIN_NAME);
+        /**
+         * 附加属性
+         */
+        ext();
+        return spanRecord;
+    }
+
+    @Override
+    public SpanRecord exceptionTrace(Advice advice) {
+        if (LettuceMethodInterceptor.interceptorApplied.get()) {
+            return null;
+        }
+        SpanRecord spanRecord = new SpanRecord();
+        spanRecord.setResponse(advice.getThrowable());
+        spanRecord.setResultCode(ResultCode.INVOKE_RESULT_FAILED);
+        spanRecord.setMiddlewareName(LettuceConstants.MIDDLEWARE_NAME);
+        spanRecord.setCallbackMsg(LettuceConstants.PLUGIN_NAME);
+        /**
+         * 附加属性
+         */
+        ext();
+        return spanRecord;
+    }
+
+    private static Field keyField;
+
+    private Object[] toArgs(Object[] args) {
+        List singularArguments = Reflect.on(args[2]).get("singularArguments");
+        Object[] ret = new Object[singularArguments.size()];
+        try {
+            if (keyField == null) {
+                keyField = singularArguments.get(0).getClass().getDeclaredField("key");
+                if (keyField == null) {
+                    return new Object[]{((CommandArgs<byte[], byte[]>) args[2]).toCommandString()};
+                }
+                keyField.setAccessible(true);
+            }
+            for (int i = 0; i < singularArguments.size(); i++) {
+                String v = new String((byte[]) keyField.get(singularArguments.get(i)));
+                // 第一个参数是key
+                if(i == 0){
+                    if(Pradar.isClusterTest() && !Pradar.isClusterTestPrefix(v)){
+                        v = Pradar.addClusterTestPrefix(v);
+                    }
+                }
+                ret[i] = v;
+            }
+            return ret;
+        } catch (NoSuchFieldException e) {
+            logger.error("redis_lettuce_002: CommandArgs.KeyArgument not exists field :key", e);
+        } catch (IllegalAccessException e) {
+
+        }
+        return new Object[]{((CommandArgs<byte[], byte[]>) args[2]).toCommandString()};
+    }
+
+    public static String getMethodNameExt(Object... args) {
+        if (args == null || args.length == 0) {
+            return "";
+        }
+        try {
+            String key = ParameterUtils.toString(200, Charset.forName("UTF-8").newDecoder().decode(((CommandArgs<byte[], byte[]>) args[2]).getFirstEncodedKey()));
+            if(Pradar.isClusterTest() && !Pradar.isClusterTestPrefix(key)){
+                key = Pradar.addClusterTestPrefix(key);
+            }
+            return key;
+        } catch (CharacterCodingException e) {
+            logger.error("redis_lettuce_003: decode args falied", e);
+            return ParameterUtils.toString(200, args[2]);
+        }
+    }
+}

--- a/instrument-modules/user-modules/module-redis-lettuce/src/main/resources/module.config
+++ b/instrument-modules/user-modules/module-redis-lettuce/src/main/resources/module.config
@@ -8,5 +8,5 @@ import-package=com.pamirs.pradar.*,com.pamirs.attach.plugin.common.datasource.*
 # dependency of module or swither,multi split with comma
 dependencies=pradar-core,datasource-common
 simulator-version=1.0.0-
-module-version=2.0.0.0
+module-version=2.0.0.1
 dependencies-info=pradar-core@2.0.0.0,datasource-common@2.0.0.0


### PR DESCRIPTION
支持spring-data-redis内置lettuce，支持connection.execute（....）使用形式
<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div data-zone-id="0" data-line-index="0" style="white-space: pre;">

spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("set",k1,value)（业务） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过get(k1)获取返回值result | k1 | 返回值=a | P
-- | -- | -- | -- | -- | -- | --
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("set",k1,value)（影子） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过get(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("set",k1,value)（调试） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过get(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("sadd",k1,value)（业务） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过spop(k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("sadd",k1,value)（影子） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过spop(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("sadd",k1,value)（调试） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过spop(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("lpush",k1,value)（业务） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过lpop(k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("lpush",k1,value)（影子） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过lpop(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("lpush",k1,value)（调试） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过lpop(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("zadd",k1,value)（业务） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过zrangeByScoret(k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("zadd",k1,value)（影子） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过zrangeByScore(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("zadd",k1,value)（调试） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.通过zrangeByScore(PT_k1)获取返回值result | k1 | 返回值=a | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("set",k1,value)（业务trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("set",k1,value)（影子trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("sadd",k1,value)（业务trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("sadd",k1,value)（影子trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("lpush",k1,value)（业务trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("lpush",k1,value)（影子trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("zadd",k1,value)（业务trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P
spring-data-redis（内部嵌套lettuce） | 2.0.6.RELEASE | connection.execute("zadd",k1,value)（影子trace查看） | 1.测试应用调用该方法，并提供http入口 2.测试框架中入参为k1，value为a调用http入口 3.查看agent的trace日志 | k1 | trace显示正确 | P

</div>

redis-lettuce的测试用例也都通过