### PR TITLE
es5.4.1支持

### DIFF
--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/ElasticSearchPlugin.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/ElasticSearchPlugin.java
@@ -133,9 +133,22 @@ public class ElasticSearchPlugin extends ModuleLifecycleAdapter implements Exten
                         "org.elasticsearch.client.HttpAsyncResponseConsumerFactory", "org.elasticsearch.client.ResponseListener",
                         "org.apache.http.Header[]");
 
+                InstrumentMethod performRequestAsyncMethodLowVersionTrace = target.getDeclaredMethod("performRequestAsync",
+                        "long", "org.elasticsearch.client.RestClient$HostTuple", "org.apache.http.client.methods.HttpRequestBase", "java.util.Set",
+                        "org.elasticsearch.client.HttpAsyncResponseConsumerFactory",
+                        "org.elasticsearch.client.RestClient$FailureTrackingResponseListener");
+
+
                 if (performRequestAsyncMethod != null) {
                     performRequestAsyncMethod.addInterceptor(Listeners.of(RestClientPerformAsyncRequestInterceptor.class, "SHADOW_SEARCH_SCOPE", ExecutionPolicy.BOUNDARY, Interceptors.SCOPE_CALLBACK));
                 }
+
+
+                if (performRequestAsyncMethodLowVersionTrace != null){
+                    performRequestAsyncMethodLowVersionTrace.addInterceptor(
+                            Listeners.of(RestClientPerformAsyncLowVersionRequestTraceInterceptor.class, "SHADOW_SEARCH_SCOPE", ExecutionPolicy.BOUNDARY, Interceptors.SCOPE_CALLBACK));
+                }
+
 
                 if (performRequestAsyncMethodLowVersion != null) {
                     performRequestAsyncMethodLowVersion.addInterceptor(

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/AbstractRestClientShadowServerInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/AbstractRestClientShadowServerInterceptor.java
@@ -14,8 +14,6 @@
  */
 package com.pamirs.attach.plugin.es.interceptor;
 
-import java.io.IOException;
-
 import com.pamirs.attach.plugin.es.common.RequestIndexRename;
 import com.pamirs.attach.plugin.es.common.RequestIndexRenameProvider;
 import com.pamirs.attach.plugin.es.shadowserver.ShadowEsClientHolder;
@@ -30,6 +28,8 @@ import com.pamirs.pradar.pressurement.agent.shared.service.GlobalConfig;
 import com.shulie.instrument.simulator.api.listener.ext.Advice;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.elasticsearch.client.RestClient;
+
+import java.io.IOException;
 
 /**
  * @author jirenhe | jirenhe@shulie.io
@@ -54,6 +54,11 @@ public abstract class AbstractRestClientShadowServerInterceptor extends CutoffIn
         }
     }
 
+    /**
+     * 低版本es无法使用
+     * @param advice
+     * @return
+     */
     protected CutOffResult doShadowIndexInterceptor(Advice advice) {
         Object[] args = advice.getParameterArray();
         RequestIndexRename requestIndexRename = RequestIndexRenameProvider.get(args[0]);

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformAsyncLowVersionRequestTraceInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformAsyncLowVersionRequestTraceInterceptor.java
@@ -1,0 +1,120 @@
+/*
+ * *
+ *  * Copyright 2021 Shulie Technology, Co.Ltd
+ *  * Email: shulie@shulie.io
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.pamirs.attach.plugin.es.interceptor;
+
+import com.pamirs.attach.plugin.es.utils.AsyncLowTraceUtils;
+import com.pamirs.pradar.MiddlewareType;
+import com.pamirs.pradar.ResultCode;
+import com.pamirs.pradar.interceptor.SpanRecord;
+import com.pamirs.pradar.interceptor.TraceInterceptorAdaptor;
+import com.shulie.instrument.simulator.api.listener.ext.Advice;
+import org.apache.http.HttpHost;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.methods.HttpRequestBase;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * @author angju
+ * @date 2022/4/12 09:33
+ */
+public class RestClientPerformAsyncLowVersionRequestTraceInterceptor extends TraceInterceptorAdaptor {
+
+
+    @Override
+    public String getPluginName() {
+        return "es";
+    }
+
+    @Override
+    public int getPluginType() {
+        return MiddlewareType.TYPE_SEARCH;
+    }
+
+    @Override
+    public SpanRecord beforeTrace(Advice advice) {
+        SpanRecord spanRecord = new SpanRecord();
+        Object hostTuple = advice.getParameterArray()[1];
+        HttpRequestBase requestBase = (HttpRequestBase) advice.getParameterArray()[2];
+        spanRecord.setService(getService(hostTuple, advice.getTarget().hashCode()));
+        spanRecord.setMethod(requestBase.getURI().getPath());
+        return spanRecord;
+    }
+
+    private String getService(Object hostTuple, int hashCode){
+        if (AsyncLowTraceUtils.map.get(hashCode) != null){
+            return AsyncLowTraceUtils.map.get(hashCode);
+        }
+        synchronized (AsyncLowTraceUtils.map){
+            if (AsyncLowTraceUtils.map.get(hashCode) != null){
+                return AsyncLowTraceUtils.map.get(hashCode);
+            }
+            StringBuilder stringBuilder = new StringBuilder();
+            Field authCacheField = null;
+            boolean authCacheFieldAccessible = false;
+            Field mapField = null;
+            boolean mapFieldAccessible = false;
+            try {
+                authCacheField = hostTuple.getClass().getDeclaredField("authCache");
+                authCacheFieldAccessible = authCacheField.isAccessible();
+                authCacheField.setAccessible(true);
+                AuthCache authCache = (AuthCache) authCacheField.get(hostTuple);
+                mapField = authCache.getClass().getDeclaredField("map");
+                mapFieldAccessible = mapField.isAccessible();
+                mapField.setAccessible(true);
+                Map<HttpHost, byte[]> map = (Map<HttpHost, byte[]>) mapField.get(authCache);
+                for (HttpHost httpHost : map.keySet()){
+                    stringBuilder.append(httpHost.toString()).append(";");
+                }
+            }catch (Throwable t){
+                LOGGER.error("RestClientPerformAsyncLowVersionRequestTraceInterceptor getService error {}", t);
+            } finally {
+                if (authCacheField != null){
+                    authCacheField.setAccessible(authCacheFieldAccessible);
+                }
+                if (mapField != null){
+                    mapField.setAccessible(mapFieldAccessible);
+                }
+            }
+            AsyncLowTraceUtils.map.put(hashCode, stringBuilder.toString());
+            return stringBuilder.toString();
+        }
+
+    }
+
+
+
+    @Override
+    public SpanRecord afterTrace(Advice advice) {
+        SpanRecord spanRecord = new SpanRecord();
+        spanRecord.setResultCode(ResultCode.INVOKE_RESULT_SUCCESS);
+        return spanRecord;
+    }
+
+
+    @Override
+    public SpanRecord exceptionTrace(Advice advice) {
+        SpanRecord spanRecord = new SpanRecord();
+        spanRecord.setResultCode(ResultCode.INVOKE_RESULT_FAILED);
+        spanRecord.setResponse(advice.getThrowable());
+        return spanRecord;
+    }
+
+
+}

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/utils/AsyncLowTraceUtils.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/utils/AsyncLowTraceUtils.java
@@ -1,0 +1,30 @@
+/*
+ * *
+ *  * Copyright 2021 Shulie Technology, Co.Ltd
+ *  * Email: shulie@shulie.io
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.pamirs.attach.plugin.es.utils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author angju
+ * @date 2022/4/12 10:33
+ */
+public class AsyncLowTraceUtils {
+    /** restClient hashCode 2 serviceAddress **/
+    public static Map<Integer, String> map = new ConcurrentHashMap<Integer, String>(1, 4);
+}

--- a/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/Pradar.java
+++ b/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/Pradar.java
@@ -176,6 +176,11 @@ public final class Pradar {
     static public final String CLUSTER_TEST_PREFIX = getClusterTestPrefix();
 
     /**
+     * 全链路压测前缀
+     */
+    static public final String CLUSTER_TEST_PREFIX_LOWER = getClusterTestPrefixLower();
+
+    /**
      * 全链路压测前缀 非下划线后缀
      */
     static public final String CLUSTER_TEST_PREFIX_ROD = getClusterTestPrefixRod();
@@ -752,6 +757,20 @@ public final class Pradar {
         }
 
         return agentId;
+    }
+
+    /**
+     * 获取压测前缀
+     *
+     * @return
+     */
+    public static String getClusterTestPrefixLower() {
+        String prefix = System.getProperty("pradar.cluster.test.prefix.lower");
+        if (StringUtils.isBlank(prefix)) {
+            prefix = "pt_";
+        }
+        System.out.println("SIMULATOR: cluster test prefix lower is:" + prefix);
+        return prefix;
     }
 
     /**


### PR DESCRIPTION
1、es5.4.1low version用法支持、trace支持
2、压测标前缀小写


trace :
3e3fa8c016497344786521002de27b|1649734494580|c55cf771-12b5-49e4-a566-c84723a5f6f3|test|46|192.168.63.62-57979|0.1|6|es-541|8|es|http://192.168.1.180:9200;|/pt_angju_test/user/5|00|||true~false~false~false||#1|@es-541~~|@es-541~~~0~0||@tn@3667f4c9eba2ab35cb311c63c3a1e104@|@@st49:http-nio-8081-exec-3@nidempty@et49:http-nio-8081-exec-3

测试用例：
takeTime:2022-04-12 11:36:56,takeTime:35614 testClassName:com.shulie.agent.plugin.elasticsearch.ElasticSearchLow541IT, projectName:elastic-search-5.4.1-test, dependecies:org.elasticsearch:elasticsearch:5.4.1, testItNum:12, successItNum:12, failedItNum:0, 
	success:
		test_16_docAdd_normal: 添加业务文档 take time : 956
		test_17_docAdd_test: 添加影子文档 take time : 124
		test_18_docAdd_debug: debug添加影子文档 take time : 81
		test_19_docUpdate_normal: 更新业务文档 take time : 124
		test_20_docUpdate_test: 更新影子文档 take time : 162
		test_21_docUpdate_test: debug操作更新文档 take time : 109
		test_22_docQuery_normal: 业务查询文档 take time : 72
		test_23_docDelete_normal: 业务删除文档 take time : 113
		test_23_docQuery_normal: 压测查询文档 take time : 124
		test_24_docDelete_normal: 压测删除文档 take time : 95
		test_24_docQuery_normal: debug查询文档 take time : 129
		test_25_docDelete_normal: debug删除文档 take time : 108
	failed:
		





