### PR TITLE
调整lettuce trace格式

### DIFF
--- a/instrument-modules/user-modules/module-redis-lettuce/pom.xml
+++ b/instrument-modules/user-modules/module-redis-lettuce/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <module-name>redis-lettuce</module-name>
     </properties>
-    <version>2.0.1.1</version>
+    <version>2.0.1.0</version>
 
     <dependencies>
         <dependency>

--- a/instrument-modules/user-modules/module-redis-lettuce/pom.xml
+++ b/instrument-modules/user-modules/module-redis-lettuce/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <module-name>redis-lettuce</module-name>
     </properties>
-    <version>2.0.1.0</version>
+    <version>2.0.1.1</version>
 
     <dependencies>
         <dependency>

--- a/instrument-modules/user-modules/module-redis-lettuce/src/main/java/com/pamirs/attach/plugin/lettuce/interceptor/LettuceMethodInterceptor.java
+++ b/instrument-modules/user-modules/module-redis-lettuce/src/main/java/com/pamirs/attach/plugin/lettuce/interceptor/LettuceMethodInterceptor.java
@@ -80,8 +80,8 @@ public class LettuceMethodInterceptor extends TraceInterceptorAdaptor {
         Object target = advice.getTarget();
         SpanRecord spanRecord = new SpanRecord();
         appendEndPoint(target, spanRecord);
-        spanRecord.setService(methodName);
-        spanRecord.setMethod(getMethodNameExt(args));
+        spanRecord.setMethod(methodName);
+        spanRecord.setService(getMethodNameExt(args));
         spanRecord.setRequest(toArgs(args));
         spanRecord.setMiddlewareName(LettuceConstants.MIDDLEWARE_NAME);
         return spanRecord;

--- a/instrument-modules/user-modules/module-redis-lettuce/src/main/resources/README.md
+++ b/instrument-modules/user-modules/module-redis-lettuce/src/main/resources/README.md
@@ -1,16 +1,3 @@
-注意！！！！！
-每次更新插件请都更新内容到以下内容，
-redis-lettuce中间件支持模块，
-新增模块版本信息，初始版本为1.0.0，README.md为模块更新内容描述文件，
 
-
-2.0.0.1版本：
-支持connection execute方式
-工单解决：https://devops.aliyun.com/task/620b71fa87f6ef003fb05387
-
-2.0.1.0版本：
-支持影子库账密前缀处理。
-仿真系统新增配置项：
-shadow.datasource.account.prefix（前缀参数，默认是PT_）
-shadow.datasource.account.suffix（后缀参数，默认是空字符串）
-说明：假设原业务库账号为 admin，密码为 password。现影子库页面上无需配置账号密码，会自动以 PT_admin 作为影子库账号, PT_password 作为影子库密码去连接影子库。
+2.0.1.1版本：
+trace日志service和method的位置错了，调整回来

--- a/instrument-modules/user-modules/module-redis-lettuce/src/main/resources/module.config
+++ b/instrument-modules/user-modules/module-redis-lettuce/src/main/resources/module.config
@@ -8,5 +8,5 @@ import-package=com.pamirs.pradar.*,com.pamirs.attach.plugin.common.datasource.*
 # dependency of module or swither,multi split with comma
 dependencies=pradar-core,datasource-common
 simulator-version=1.0.0-
-module-version=2.0.1.0
+module-version=2.0.1.1
 dependencies-info=pradar-core@2.0.1.0,datasource-common@2.0.0.0


### PR DESCRIPTION
lettuce的trace service和metho位置错了，调整回来
243fa8c016529534894871485d13470001|1652953489488|93fc707e-16ae-4913-8ba3-c0526bdd9f81|test|90458|192.168.63.36-84935|9|5|lettuce-core|1|redis|PT_testMaxRedisExpireTimeSetExShadow|ttl|00|{PT_testMaxRedisExpireTimeSetExShadow}||false~false~false~false|redis-lettuce|#1|@lettuce-core~~|@lettuce-core~192.168.1.146~6379~0~0|_13@##{"ext":{"client":"lettuce","database":3,"model":"single","name":"lettuce","nodes":"192.168.1.146:6379","password":"pamirs@2020"},"moduleId":"redis-lettuce"}|@tn@99ce433851284c4f552b1ff495d5f12d@|@@st123:io.lettuce:lettuce-core:6.0.2.RELEASElettuce-coreio.lettuce:lettuce-core:6.0.2.RELEASE-Thread@nidempty@et123:io.lettuce:lettuce-core:6.0.2.RELEASElettuce-coreio.lettuce:lettuce-core:6.0.2.RELEASE-Thread