### PR TITLE
Bugfix/zk heartbeat

### DIFF
--- a/instrument-modules/user-modules/module-pradar-register/src/main/java/com/shulie/instrument/module/register/register/impl/ZookeeperRegister.java
+++ b/instrument-modules/user-modules/module-pradar-register/src/main/java/com/shulie/instrument/module/register/register/impl/ZookeeperRegister.java
@@ -20,7 +20,6 @@ import com.pamirs.pradar.*;
 import com.pamirs.pradar.common.HttpUtils;
 import com.pamirs.pradar.common.HttpUtils.HttpResult;
 import com.pamirs.pradar.common.IOUtils;
-import com.pamirs.pradar.common.PropertyPlaceholderHelper;
 import com.pamirs.pradar.common.RuntimeUtils;
 import com.pamirs.pradar.event.ErrorEvent;
 import com.pamirs.pradar.event.Event;
@@ -481,7 +480,11 @@ public class ZookeeperRegister implements Register {
 
                 try {
                     if (!zkClient.exists(heartbeatPath)) {
-                        zkClient.ensureDirectoryExists(heartbeatPath);
+                        LOGGER.info("{}节点不存在，等待重新创建",heartbeatPath);
+                        //zkClient.ensureDirectoryExists(heartbeatPath);
+                        //等待watcher创建
+                        scanJarFuture = ExecutorServiceFactory.getFactory().schedule(this, 5, TimeUnit.SECONDS);
+                        return;
                     }
                 } catch (Throwable e) {
                     LOGGER.error("[pradar-register] zk ensureDirectoryExists err: {}!", heartbeatPath);

--- a/instrument-modules/user-modules/module-pradar-register/src/main/java/com/shulie/instrument/module/register/zk/impl/CuratorZkHeartbeatNode.java
+++ b/instrument-modules/user-modules/module-pradar-register/src/main/java/com/shulie/instrument/module/register/zk/impl/CuratorZkHeartbeatNode.java
@@ -110,7 +110,7 @@ public class CuratorZkHeartbeatNode implements ZkHeartbeatNode {
                 }
             }
             logger.info("heartbeat node is set alive, path={}", path);
-            client.checkExists().usingWatcher(watcher).forPath(path);
+            addWatcher();
             alive.set(true);
         }
     }
@@ -149,13 +149,28 @@ public class CuratorZkHeartbeatNode implements ZkHeartbeatNode {
     private final Watcher watcher = new Watcher() {
         @Override
         public void process(WatchedEvent event) {
+            logger.info("receive node event：{}",event.toString());
             if (event.getType() == Watcher.Event.EventType.NodeDeleted) {
                 try {
                     reset();
                 } catch (Throwable e) {
-                    logger.warn("fail to reset in watch event, path={}", path, e);
+                    logger.error("fail to reset in watch event, path={}", path, e);
                 }
+            }else {
+                //Watcher监听器是一次性,需重置watcher
+                addWatcher();
             }
         }
     };
+
+
+
+    private void addWatcher(){
+        try {
+            logger.info("add watcher for node:{}",path);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+        } catch (Exception e) {
+            logger.error("fail to add watcher for path={}", path, e);
+        }
+    }
 }

--- a/instrument-modules/user-modules/module-pradar-register/src/main/resources/README.md
+++ b/instrument-modules/user-modules/module-pradar-register/src/main/resources/README.md
@@ -1,4 +1,3 @@
-注意！！！！！
-每次更新插件请都更新内容到以下内容，
-pradar-register中间件支持模块，
-新增模块版本信息，初始版本为1.0.0，README.md为模块更新内容描述文件，
+bug-fix
+1、客户端心跳线程更新节点数据时，若节点不存在，创建节点时为永久节点，导致应用消亡后节点仍存在。
+2、原生watcher api是一次性的，更新线程重置heartbeatData后，会触发NodeDataChanged事件，导致watcher失效,无法监听NodeDelete事件。

--- a/simulator-agent/simulator-agent-core/src/main/java/com/shulie/instrument/simulator/agent/core/zk/impl/CuratorZkHeartbeatNode.java
+++ b/simulator-agent/simulator-agent-core/src/main/java/com/shulie/instrument/simulator/agent/core/zk/impl/CuratorZkHeartbeatNode.java
@@ -14,13 +14,11 @@
  */
 package com.shulie.instrument.simulator.agent.core.zk.impl;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import com.shulie.instrument.simulator.agent.core.zk.ZkHeartbeatNode;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.ZKPaths;
-import com.shulie.instrument.simulator.agent.core.zk.ZkHeartbeatNode;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
@@ -28,6 +26,8 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -120,7 +120,7 @@ public class CuratorZkHeartbeatNode implements ZkHeartbeatNode {
                 }
             }
             logger.info("heartbeat node is set alive, path={}", path);
-            client.checkExists().usingWatcher(watcher).forPath(path);
+            addWatcher();
             alive.set(true);
         }
     }
@@ -157,13 +157,27 @@ public class CuratorZkHeartbeatNode implements ZkHeartbeatNode {
     private final Watcher watcher = new Watcher() {
         @Override
         public void process(WatchedEvent event) {
+            logger.info("node event:{}",event.toString());
             if (event.getType() == Watcher.Event.EventType.NodeDeleted) {
                 try {
                     reset();
                 } catch (Throwable e) {
                     logger.error("fail to reset in watch event, path={}", path, e);
                 }
+            }else {
+                //重置watcher
+                addWatcher();
             }
         }
     };
+
+
+    private void addWatcher(){
+        try {
+            logger.info("add watcher for node:{}",path);
+            client.checkExists().usingWatcher(watcher).forPath(path);
+        } catch (Exception e) {
+            logger.error("fail to add watcher for path={}", path, e);
+        }
+    }
 }


### PR DESCRIPTION
bug-fix
1、客户端心跳线程更新节点数据时，若节点不存在，创建节点时为永久节点，导致应用消亡后节点仍存在。
2、原生watcher api是一次性的，更新线程重置heartbeatData后，会触发NodeDataChanged事件，导致watcher失效,无法监听NodeDelete事件。