### PR TITLE
es-rest-client 6.1.4版本影子集群支持

### DIFF
--- a/instrument-modules/user-modules/module-elasticsearch/pom.xml
+++ b/instrument-modules/user-modules/module-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <module-name>elasticsearch</module-name>
     </properties>
-    <version>2.0.0.2</version>
+    <version>2.0.0.4</version>
 
     <dependencies>
         <dependency>
@@ -113,7 +113,7 @@
                 <configuration>
                     <tasks>
                         <echo>Removing dummy classes</echo>
-                        <delete dir="target/classes/org/elasticsearch" />
+                        <delete dir="target/classes/org/elasticsearch"/>
                     </tasks>
                 </configuration>
             </plugin>

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/ElasticsearchConstants.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/ElasticsearchConstants.java
@@ -24,7 +24,9 @@ import com.pamirs.pradar.MiddlewareType;
  */
 public class ElasticsearchConstants {
     public final static String PLUGIN_NAME = "elasticsearch";
+
     public final static int PLUGIN_TYPE = MiddlewareType.TYPE_SEARCH;
+
     public final static String MODULE_NAME = "elasticsearch";
 
     public final static String REFLECT_FIELD_CLIENT = "client";

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/common/impl/AbstractReadRequestIndexRename.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/common/impl/AbstractReadRequestIndexRename.java
@@ -30,7 +30,6 @@ public abstract class AbstractReadRequestIndexRename extends AbstractRequestInde
 
     @Override
     public final List<String> reindex(Object target) {
-        //TODO
         return reindex0(target);
     }
 
@@ -38,7 +37,6 @@ public abstract class AbstractReadRequestIndexRename extends AbstractRequestInde
 
     @Override
     public final List<String> getIndex(Object target) {
-        //TODO
         return getIndex0(target);
     }
 
@@ -46,7 +44,6 @@ public abstract class AbstractReadRequestIndexRename extends AbstractRequestInde
 
     @Override
     protected String[] toClusterTestIndex(String[] indexes) {
-
         String[] newIndexes = new String[indexes.length];
         for (int i = 0; i < indexes.length; i++) {
             /**

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/common/impl/AbstractWriteRequestIndexRename.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/common/impl/AbstractWriteRequestIndexRename.java
@@ -31,7 +31,6 @@ public abstract class AbstractWriteRequestIndexRename extends AbstractRequestInd
 
     @Override
     public final List<String> reindex(Object target) {
-        //TODO
         return reindex0(target);
     }
 
@@ -39,7 +38,6 @@ public abstract class AbstractWriteRequestIndexRename extends AbstractRequestInd
 
     @Override
     public final List<String> getIndex(Object target) {
-        //TODO
         return getIndex0(target);
     }
 

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformAsyncLowVersionRequestInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformAsyncLowVersionRequestInterceptor.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * See the License for the specific language governing permissions and
@@ -40,22 +40,19 @@ public class RestClientPerformAsyncLowVersionRequestInterceptor extends Abstract
 
     private volatile Method performRequestAsyncMethod;
 
-
     @Override
-    public CutOffResult doShadowIndexInterceptor(Advice advice){
-        if (!RestClientHighLowFlag.isHigh){
+    public CutOffResult doShadowIndexInterceptor(Advice advice) {
+        if (!RestClientHighLowFlag.isHigh) {
             String endpoint = (String) advice.getParameterArray()[1];
-            if (endpoint.startsWith("/")){
+            if (endpoint.startsWith("/")) {
                 //es索引名称得小写
                 endpoint = endpoint.replaceFirst("/", "/" + Pradar.CLUSTER_TEST_PREFIX_LOWER);
-            } else if (!endpoint.startsWith(Pradar.CLUSTER_TEST_PREFIX_LOWER)){
+            } else if (!endpoint.startsWith(Pradar.CLUSTER_TEST_PREFIX_LOWER)) {
                 endpoint = Pradar.addClusterTestPrefix(endpoint);
             }
-
             advice.changeParameter(1, endpoint);
         }
         return CutOffResult.PASSED;
-
     }
 
     @Override

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformAsyncLowVersionRequestTraceInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformAsyncLowVersionRequestTraceInterceptor.java
@@ -37,7 +37,6 @@ import java.util.Map;
  */
 public class RestClientPerformAsyncLowVersionRequestTraceInterceptor extends TraceInterceptorAdaptor {
 
-
     @Override
     public String getPluginName() {
         return "es";
@@ -100,10 +99,7 @@ public class RestClientPerformAsyncLowVersionRequestTraceInterceptor extends Tra
             AsyncLowTraceUtils.map.put(hashCode, stringBuilder.toString());
             return stringBuilder.toString();
         }
-
     }
-
-
 
     @Override
     public SpanRecord afterTrace(Advice advice) {
@@ -126,6 +122,4 @@ public class RestClientPerformAsyncLowVersionRequestTraceInterceptor extends Tra
         spanRecord.setResponse(advice.getThrowable());
         return spanRecord;
     }
-
-
 }

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformRequestInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientPerformRequestInterceptor.java
@@ -37,5 +37,4 @@ public class RestClientPerformRequestInterceptor extends AbstractRestClientShado
     protected boolean doCheck(Object target, String methodName, Object[] args) {
         return args.length == 1 && args[0] instanceof Request;
     }
-
 }

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientTraceInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestClientTraceInterceptor.java
@@ -74,7 +74,6 @@ public class RestClientTraceInterceptor extends TraceInterceptorAdaptor {
             record.setPassedCheck(true);
         }
         return record;
-
     }
 
     private String toString(Collection<String> list) {
@@ -97,7 +96,6 @@ public class RestClientTraceInterceptor extends TraceInterceptorAdaptor {
         record.setRequest(args[0]);
         //record.setResponse(result);
         return record;
-
     }
 
     @Override

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestHighLevelClientInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/RestHighLevelClientInterceptor.java
@@ -158,7 +158,6 @@ public class RestHighLevelClientInterceptor extends TraceInterceptorAdaptor {
         record.setRequest(args[0]);
         //record.setResponse(result);
         return record;
-
     }
 
     @Override

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/TransportClientTraceInterceptor.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/interceptor/TransportClientTraceInterceptor.java
@@ -71,7 +71,6 @@ public class TransportClientTraceInterceptor extends TraceInterceptorAdaptor {
         record.setMethod(advice.getBehaviorName());
         record.setRemoteIp(parseAddressAndPort(client));
         return record;
-
     }
 
     @Override
@@ -101,7 +100,6 @@ public class TransportClientTraceInterceptor extends TraceInterceptorAdaptor {
         record.setRequest(args[1]);
         //record.setResponse(result);
         return record;
-
     }
 
     @Override

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/ShadowEsClientHolder.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/ShadowEsClientHolder.java
@@ -4,23 +4,15 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package com.pamirs.attach.plugin.es.shadowserver;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.pamirs.attach.plugin.es.shadowserver.rest.RestClientDefinitionStrategy;
 import com.pamirs.attach.plugin.es.shadowserver.rest.definition.RestClientDefinition;
@@ -38,6 +30,7 @@ import com.pamirs.pradar.pressurement.agent.shared.service.EventRouter;
 import com.pamirs.pradar.pressurement.agent.shared.service.GlobalConfig;
 import com.shulie.instrument.simulator.api.reflect.Reflect;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.transport.TransportClient;
@@ -46,6 +39,15 @@ import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author jirenhe | jirenhe@shulie.io
@@ -57,14 +59,18 @@ public class ShadowEsClientHolder {
     protected final static Logger LOGGER = LoggerFactory.getLogger(ShadowEsClientHolder.class.getName());
 
     private final static Map<TransportClient, TransportClient> transportClientMapping =
-        new ConcurrentHashMap<TransportClient, TransportClient>();
+            new ConcurrentHashMap<TransportClient, TransportClient>();
 
     private final static Map<RestClient, RestClient> restClientMapping =
-        new ConcurrentHashMap<RestClient, RestClient>();
+            new ConcurrentHashMap<RestClient, RestClient>();
 
     private static final AtomicBoolean isAdded = new AtomicBoolean(false);
 
     private static boolean isLowVersionRestClient = false;
+
+    private static boolean IS_REST_CLIENT_614 = false;
+
+    private static boolean JUDGE_IS_614 = false;
 
     public static void addListener() {
         if (!isAdded.compareAndSet(false, true)) {
@@ -75,8 +81,8 @@ public class ShadowEsClientHolder {
             @Override
             public EventResult onEvent(IEvent event) {
                 if (event instanceof ShadowEsServerDisableEvent
-                    || event instanceof ShadowEsServerRegisterEvent) {
-                    List<ShadowEsServerConfig> shadowEsServerConfigs = (List<ShadowEsServerConfig>)event.getTarget();
+                        || event instanceof ShadowEsServerRegisterEvent) {
+                    List<ShadowEsServerConfig> shadowEsServerConfigs = (List<ShadowEsServerConfig>) event.getTarget();
                     synchronized (ShadowEsClientHolder.class) {
                         for (ShadowEsServerConfig config : shadowEsServerConfigs) {
                             for (Entry<TransportClient, TransportClient> entry : transportClientMapping.entrySet()) {
@@ -149,7 +155,7 @@ public class ShadowEsClientHolder {
         ShadowEsServerConfig shadowEsServerConfig = findMatchShadowEsServerConfig(nodesAddressAsString);
         if (shadowEsServerConfig == null) {
             throw new PressureMeasureError(String.format(
-                "影子集群未配置，业务节点：%s", StringUtils.join(nodesAddressAsString, ",")
+                    "影子集群未配置，业务节点：%s", StringUtils.join(nodesAddressAsString, ",")
             ));
         }
         RestClientDefinition restClientDefinition = RestClientDefinitionStrategy.match(target);
@@ -161,7 +167,7 @@ public class ShadowEsClientHolder {
         ShadowEsServerConfig shadowEsServerConfig = findMatchShadowEsServerConfig(nodesAddressAsString);
         if (shadowEsServerConfig == null) {
             throw new PressureMeasureError(String.format(
-                "影子集群未配置，业务节点：%s", StringUtils.join(nodesAddressAsString, ",")
+                    "影子集群未配置，业务节点：%s", StringUtils.join(nodesAddressAsString, ",")
             ));
         }
         TransportClientDefinition transportClientDefinition = TransportClientDefinitionStrategy.match(target);
@@ -170,7 +176,7 @@ public class ShadowEsClientHolder {
 
     private static ShadowEsServerConfig findMatchShadowEsServerConfig(List<String> nodesAsString) {
         for (Entry<String, ShadowEsServerConfig> entry : GlobalConfig.getInstance().getShadowEsServerConfigs()
-            .entrySet()) {
+                .entrySet()) {
             ShadowEsServerConfig shadowEsServerConfig = entry.getValue();
             if (shadowEsServerConfig.matchBusinessNodes(nodesAsString)) {
                 return shadowEsServerConfig;
@@ -185,10 +191,10 @@ public class ShadowEsClientHolder {
         for (DiscoveryNode node : nodes) {
             Object object = node.getAddress();
             if (HostAndPort.usingInetSocket) {
-                InetSocketTransportAddress address = (InetSocketTransportAddress)object;
+                InetSocketTransportAddress address = (InetSocketTransportAddress) object;
                 nodesAddressAsString.add(address.getAddress() + ":" + address.getPort());
             } else {
-                TransportAddress address = (TransportAddress)object;
+                TransportAddress address = (TransportAddress) object;
                 nodesAddressAsString.add(address.getAddress() + ":" + address.getPort());
             }
         }
@@ -196,10 +202,44 @@ public class ShadowEsClientHolder {
     }
 
     private static List<String> getNodesAddressAsString(RestClient target) {
+        judgeIs614(target);
+        List<String> nodesAddressAsString;
+        if (IS_REST_CLIENT_614) {
+            nodesAddressAsString = getLowLevelNodesAddressAsString(target);
+        } else {
+            nodesAddressAsString = getHighLevelNodesAddressAsString(target);
+        }
+        return nodesAddressAsString;
+    }
+
+    private static void judgeIs614(RestClient target) {
+        if (!JUDGE_IS_614) {
+            try {
+                // 低版本没有 org.elasticsearch.client.Node 类
+                target.getClass()
+                        .getClassLoader()
+                        .loadClass("org.elasticsearch.client.Node");
+                IS_REST_CLIENT_614 = Boolean.FALSE;
+            } catch (Throwable t) {
+                IS_REST_CLIENT_614 = Boolean.TRUE;
+            }
+        }
+    }
+
+    private static List<String> getHighLevelNodesAddressAsString(RestClient target) {
         List<Node> nodes = getNodes(target);
         List<String> nodesAddressAsString = new ArrayList<String>(nodes.size());
         for (Node node : nodes) {
             nodesAddressAsString.add(node.getHost().getHostName() + ":" + node.getHost().getPort());
+        }
+        return nodesAddressAsString;
+    }
+
+    private static List<String> getLowLevelNodesAddressAsString(RestClient target) {
+        Set<HttpHost> httpHosts = Reflect.on(Reflect.on(target).get("hostTuple")).get("hosts");
+        List<String> nodesAddressAsString = new ArrayList<String>(httpHosts.size());
+        for (HttpHost httpHost : httpHosts) {
+            nodesAddressAsString.add(httpHost.getHostName() + ":" + httpHost.getPort());
         }
         return nodesAddressAsString;
     }
@@ -223,5 +263,4 @@ public class ShadowEsClientHolder {
         transportClientMapping.clear();
         restClientMapping.clear();
     }
-
 }

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/ShadowEsClientHolder.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/ShadowEsClientHolder.java
@@ -224,6 +224,7 @@ public class ShadowEsClientHolder {
                 IS_REST_CLIENT_614 = Boolean.TRUE;
             }
         }
+        JUDGE_IS_614 = Boolean.TRUE;
     }
 
     private static List<String> getHighLevelNodesAddressAsString(RestClient target) {

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/rest/RestClientDefinitionStrategy.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/rest/RestClientDefinitionStrategy.java
@@ -14,9 +14,6 @@
  */
 package com.pamirs.attach.plugin.es.shadowserver.rest;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.pamirs.attach.plugin.es.shadowserver.rest.definition.RestClient61Definition;
 import com.pamirs.attach.plugin.es.shadowserver.rest.definition.RestClient68Definition;
 import com.pamirs.attach.plugin.es.shadowserver.rest.definition.RestClient70Definition;
@@ -25,6 +22,9 @@ import com.pamirs.pradar.exception.PressureMeasureError;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClient.FailureListener;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author jirenhe | jirenhe@shulie.io
@@ -117,5 +117,4 @@ public class RestClientDefinitionStrategy {
 
         RestClientDefinition definition();
     }
-
 }

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/rest/definition/RestClient61Definition.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/rest/definition/RestClient61Definition.java
@@ -30,5 +30,4 @@ public class RestClient61Definition extends AbstractRestClientDefinition impleme
             builder.setMaxRetryTimeoutMillis(maxRetryTimeoutMillis.intValue());
         }
     }
-
 }

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/transport/TransportClientDefinitionStrategy.java
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/java/com/pamirs/attach/plugin/es/shadowserver/transport/TransportClientDefinitionStrategy.java
@@ -14,15 +14,15 @@
  */
 package com.pamirs.attach.plugin.es.shadowserver.transport;
 
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.pamirs.attach.plugin.es.shadowserver.rest.definition.TransportClientDefinition;
 import com.pamirs.attach.plugin.es.shadowserver.transport.definition.PreBuiltTransportClientDefinition;
 import com.pamirs.attach.plugin.es.shadowserver.transport.definition.TransportClient2XDefinition;
 import com.pamirs.pradar.exception.PressureMeasureError;
 import org.elasticsearch.client.transport.TransportClient;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author jirenhe | jirenhe@shulie.io
@@ -77,5 +77,4 @@ public class TransportClientDefinitionStrategy {
 
         TransportClientDefinition definition();
     }
-
 }

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/resources/README.md
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/resources/README.md
@@ -1,1 +1,1 @@
-2.0.0.3 es支持Count请求
+elasticsearch-rest-client 6.1.4 支持影子集群模式

--- a/instrument-modules/user-modules/module-elasticsearch/src/main/resources/module.config
+++ b/instrument-modules/user-modules/module-elasticsearch/src/main/resources/module.config
@@ -8,5 +8,5 @@ import-package=com.pamirs.pradar.*
 # dependency of module or swither,multi split with comma
 dependencies=pradar-core
 simulator-version=1.0.0-
-module-version=2.0.0.3
+module-version=2.0.0.4
 dependencies-info=pradar-core@2.0.0.0

--- a/instrument-simulator/module.config
+++ b/instrument-simulator/module.config
@@ -5,4 +5,4 @@ module-id=instrument-simulator
 #export-resource=
 #import-resource=
 # dependency of module or swither,multi split with comma
-module-version=5.3.2.9
+module-version=5.3.2.10

--- a/instrument-simulator/pom.xml
+++ b/instrument-simulator/pom.xml
@@ -18,7 +18,7 @@
         <!--suppress UnresolvedMavenProperty -->
         <jdk.home>${env.JAVA_HOME}</jdk.home>
         <simulator.major.version>5.3.2</simulator.major.version>
-        <simulator.minor.version>9</simulator.minor.version>
+        <simulator.minor.version>10</simulator.minor.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
测试用例测试通过，并且在用户环境验证通过
takeTime:2022-06-14 15:56:27,takeTime:164098 testClassName:com.shulie.agent.plugin.elasticsearch.ElasticSearchTester, projectName:elastic-search-test, dependecies:org.elasticsearch:elasticsearch:7.8.1, testItNum:28, successItNum:28, failedItNum:0, 
	success:
		test_01_IndexCreate_normal: 业务创建索引 take time : 7028
		test_02_IndexCreate_test: 创建影子索引 take time : 5528
		test_03_IndexCreate_debug: debug创建索引 take time : 6122
		test_04_IndexQuery_normal: 业务查询索引是否存在 take time : 5724
		test_05_IndexQuery_test: 创建业务索引同时创建影子索引 take time : 5395
		test_06_IndexQuery_debug: debug创建业务索引同时创建影子索引 take time : 5510
		test_07_IndexClose_normal: 关闭业务索引 take time : 5645
		test_08_IndexClose_test: 关闭影子索引 take time : 5617
		test_09_IndexClose_debug: debug关闭影子索引 take time : 5667
		test_10_IndexOpen_normal: 开启业务索引 take time : 5659
		test_11_IndexOpen_test: 开启影子索引 take time : 5637
		test_12_IndexOpen_debug: debug开启影子索引 take time : 5648
		test_13_IndexDelete_normal: 删除业务索引不删除影子索引 take time : 6667
		test_14_IndexDelete_test: 删除影子索引不删除业务索引 take time : 6223
		test_15_IndexDelete_debug: debug删除影子索引不删除业务索引 take time : 6299
		test_16_docAdd_normal: 添加业务文档 take time : 5921
		test_17_docAdd_test: 添加影子文档 take time : 5614
		test_18_docAdd_debug: debug添加影子文档 take time : 5363
		test_19_docUpdate_normal: 更新业务文档 take time : 5280
		test_20_docUpdate_test: 更新影子文档 take time : 5522
		test_21_docQuery_normal: 业务查询文档 take time : 83
		test_22_docQuery_test: 影子查询文档 take time : 136
		test_23_docDelete_normal: 业务删除文档 take time : 11366
		test_24_docDelete_test: 删除影子索引不删除业务索引 take time : 11572
		test_25_lowClient_addAndQuery_normal: 低级客户端业务和影子写入查询文档 take time : 531
		test_26_lowClient_addAndQuery_test: 低级客户端影子和业务写入查询 take time : 124
		test_27_lowClient_delete_normal: 低级客户端影子和业务写入删除 take time : 342
		test_28_lowClient_delete_test: 低级客户端影子删除不删除业务文档 take time : 248
	failed:size=0