### PR TITLE
将pradar.perf.thread.collect.interval的值改成从控制台拉取数据动态生效

### DIFF
--- a/instrument-modules/user-modules/module-perf/pom.xml
+++ b/instrument-modules/user-modules/module-perf/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <module-name>perf</module-name>
     </properties>
-    <version>2.0.0.0</version>
+    <version>2.0.0.2</version>
 
     <dependencies>
         <dependency>

--- a/instrument-modules/user-modules/module-perf/src/main/java/com/shulie/instrument/simulator/perf/PerfPlugin.java
+++ b/instrument-modules/user-modules/module-perf/src/main/java/com/shulie/instrument/simulator/perf/PerfPlugin.java
@@ -17,6 +17,7 @@ package com.shulie.instrument.simulator.perf;
 import com.alibaba.fastjson.JSON;
 import com.pamirs.pradar.Pradar;
 import com.pamirs.pradar.common.HttpUtils;
+import com.pamirs.pradar.pressurement.agent.shared.service.GlobalConfig;
 import com.pamirs.pradar.pressurement.base.util.PropertyUtil;
 import com.shulie.instrument.simulator.api.CommandResponse;
 import com.shulie.instrument.simulator.api.ExtensionModule;
@@ -107,7 +108,7 @@ public class PerfPlugin extends ModuleLifecycleAdapter implements ExtensionModul
     private void collect() {
 
         // thread信息有可能数据量很大所以不需要每次都采集
-        long threadCollectInterval = simulatorConfig.getLongProperty("pradar.perf.thread.collect.interval", 60L) * 1000;
+        long threadCollectInterval = GlobalConfig.getInstance().getSimulatorDynamicConfig().perfThreadCollectInterval() * 1000;
         List<ThreadInfo> threadInfos = Collections.EMPTY_LIST;
         if ((threadInfoCollectTime.get() + threadCollectInterval) <= System.currentTimeMillis()) {
             threadInfoCollectTime.set(System.currentTimeMillis());

--- a/instrument-modules/user-modules/module-perf/src/main/resources/README.md
+++ b/instrument-modules/user-modules/module-perf/src/main/resources/README.md
@@ -1,1 +1,2 @@
-新增pradar.perf.thread.collect.interval配置，用于控制性能分析模块线程信息采集间隔，单位s
+pradar.perf.thread.collect.interval改成动态生效，执行sql如下
+INSERT INTO `t_agent_config` (`is_deleted`,`operator`,`type`,`zh_key`,`en_key`,`default_value`,`desc`,`effect_type`,`effect_mechanism`,`effect_min_version`,`effect_min_version_num`,`effect_max_version`,`effect_max_version_num`,`editable`,`value_type`,`value_option`,`project_name`,`user_app_key`,`tenant_id`,`env_code`,`sign`) VALUES (0,'superadmin',0,'性能分析:线程数据采样间隔(s)','pradar.perf.thread.collect.interval','60','性能分析:线程数据采样间隔(s),pradar.perf.thread.collect.interval',0,1,'1.0.0.0',1073741824,NULL,NULL,0,0,NULL,NULL,NULL,-1,'system',NULL);

--- a/instrument-modules/user-modules/module-perf/src/main/resources/module.config
+++ b/instrument-modules/user-modules/module-perf/src/main/resources/module.config
@@ -8,5 +8,5 @@ import-package=com.pamirs.pradar.*,com.shulie.instrument.module.register.zk.*,co
 # dependency of module or swither,multi split with comma
 dependencies=pradar-core
 simulator-version=1.0.0-
-module-version=2.0.0.1
+module-version=2.0.0.2
 dependencies-info=pradar-core@2.0.0.0

--- a/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/pressurement/agent/shared/service/SimulatorDynamicConfig.java
+++ b/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/pressurement/agent/shared/service/SimulatorDynamicConfig.java
@@ -14,17 +14,16 @@
  */
 package com.pamirs.pradar.pressurement.agent.shared.service;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.alibaba.fastjson.JSON;
-
 import com.pamirs.pradar.pressurement.entry.CheckerEntry;
 import com.shulie.instrument.simulator.api.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author angju
@@ -52,7 +51,7 @@ public class SimulatorDynamicConfig {
     private static final String SWITCH_SAVE_BUSINESS_TRACE_KEY = "pradar.switch.save.business.trace";
     private static final String BUS_REQUEST_RESPONSE_DATA_ALLOW_TRACE = "pradar.bus.request.response.data.allow.trace";
     private static final String SHADOW_REQUEST_RESPONSE_DATA_ALLOW_TRACE
-        = "pradar.shadow.request.response.data.allow.trace";
+            = "pradar.shadow.request.response.data.allow.trace";
     private static final String SECURITY_FIELD = "securityField";
 
     private static final String FILED_CHECK_RULES_SWITCH = "filed.check.rules.switch";
@@ -67,6 +66,12 @@ public class SimulatorDynamicConfig {
 
     private static final String SHADOW_DATASOURCE_ACCOUNT_SUFFIX = "shadow.datasource.account.suffix";
     private static final String DEFAULT_SHADOW_DATASOURCE_ACCOUNT_SUFFIX = "";
+
+    /**
+     * 性能分析、线程信息采集间隔 pradar.perf.thread.collect.interval
+     */
+    private static final String PRADAR_PERF_THREAD_COLLECT_INTERVAL = "pradar.perf.thread.collect.interval";
+    private static final Integer DEFAULT_PRADAR_PERF_THREAD_COLLECT_INTERVAL = 60;
 
     /**
      * trace 业务流量采样率
@@ -119,6 +124,11 @@ public class SimulatorDynamicConfig {
     private final String shadowDatasourceAccountPrefix;
     private final String shadowDatasourceAccountSuffix;
 
+    /**
+     * 性能分析线程池定时线程采集频率
+     */
+    private final Integer perfThreadCollectInterval;
+
     private Map<String, CheckerEntry> fieldCheckRules;
     private final List<String> securityFieldCollection;
 
@@ -145,10 +155,15 @@ public class SimulatorDynamicConfig {
         this.shadowDatasourceAccountPrefix = getShadowDatasourceAccountPrefix(config);
         this.shadowDatasourceAccountSuffix = getShadowDatasourceAccountSuffix(config);
         this.kafkaPtConsumerPollMaxRatio = getKafkaPtConsumerMaxPollRatio(config);
+        this.perfThreadCollectInterval = getPerfThreadCollectInterval(config);
     }
 
     public String shadowDatasourceAccountPrefix() {
         return this.shadowDatasourceAccountPrefix;
+    }
+
+    public Integer perfThreadCollectInterval() {
+        return this.perfThreadCollectInterval;
     }
 
     public String shadowDatasourceAccountSuffix() {
@@ -248,8 +263,8 @@ public class SimulatorDynamicConfig {
     }
 
     String mockStr
-        = "[{ \"url\":\"jdbc:mysql://114.55.42.181:3306/atester?useUnicode=true\", \"table\":\"m_user\", "
-        + "\"operateType\":\"insert\", \"prefix\":\"PT_\" }]";
+            = "[{ \"url\":\"jdbc:mysql://114.55.42.181:3306/atester?useUnicode=true\", \"table\":\"m_user\", "
+            + "\"operateType\":\"insert\", \"prefix\":\"PT_\" }]";
 
     private Map<String, CheckerEntry> getFieldCheckRules(Map<String, String> config) {
         if (!getFieldCheckRulesSwithcer()) {
@@ -469,6 +484,22 @@ public class SimulatorDynamicConfig {
         } catch (Throwable e) {
             LOGGER.error("getKafkaPtConsumerMaxPollRatio error {}.", e);
             return DEFAULT_PT_KAFKA_CONSUMER_MAX_POLL_RATIO;
+        }
+    }
+
+    private Integer getPerfThreadCollectInterval(Map<String, String> config) {
+        try {
+            if (config == null) {
+                return DEFAULT_PRADAR_PERF_THREAD_COLLECT_INTERVAL;
+            }
+            final String value = getConfig(config, PRADAR_PERF_THREAD_COLLECT_INTERVAL);
+            if (value == null) {
+                return DEFAULT_PRADAR_PERF_THREAD_COLLECT_INTERVAL;
+            }
+            return Integer.valueOf(value);
+        } catch (Throwable e) {
+            LOGGER.error("getKafkaPtConsumerMaxPollRatio error {}.", e);
+            return DEFAULT_PRADAR_PERF_THREAD_COLLECT_INTERVAL;
         }
     }
 

--- a/instrument-simulator/module.config
+++ b/instrument-simulator/module.config
@@ -5,4 +5,4 @@ module-id=instrument-simulator
 #export-resource=
 #import-resource=
 # dependency of module or swither,multi split with comma
-module-version=5.3.2.10
+module-version=5.3.2.18

--- a/instrument-simulator/pom.xml
+++ b/instrument-simulator/pom.xml
@@ -18,7 +18,7 @@
         <!--suppress UnresolvedMavenProperty -->
         <jdk.home>${env.JAVA_HOME}</jdk.home>
         <simulator.major.version>5.3.2</simulator.major.version>
-        <simulator.minor.version>17</simulator.minor.version>
+        <simulator.minor.version>18</simulator.minor.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
由于性能分析数据中会大量上报线程数据把控制台数据库cpu打满，所以需要降低线程数据上报频率。
通过pradar.perf.thread.collect.interval参数来控制频率。