### PR TITLE
修复spring-kafka trace日志group丢失问题

### DIFF
--- a/instrument-modules/user-modules/module-apache-kafka/pom.xml
+++ b/instrument-modules/user-modules/module-apache-kafka/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <module-name>apache-kafka</module-name>
     </properties>
-    <version>2.0.0.8</version>
+    <version>2.0.0.9</version>
 
     <dependencies>
         <dependency>

--- a/instrument-modules/user-modules/module-apache-kafka/src/main/java/com/pamirs/attach/plugin/apache/kafka/interceptor/ConsumerRecordEntryPointInterceptor.java
+++ b/instrument-modules/user-modules/module-apache-kafka/src/main/java/com/pamirs/attach/plugin/apache/kafka/interceptor/ConsumerRecordEntryPointInterceptor.java
@@ -16,6 +16,7 @@ package com.pamirs.attach.plugin.apache.kafka.interceptor;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Resource;
 
@@ -39,10 +40,8 @@ import com.shulie.instrument.simulator.api.annotation.ListenerBehavior;
 import com.shulie.instrument.simulator.api.listener.ext.Advice;
 import com.shulie.instrument.simulator.api.reflect.Reflect;
 import com.shulie.instrument.simulator.api.resource.DynamicFieldManager;
-import org.apache.commons.lang.StringUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -63,6 +62,8 @@ public class ConsumerRecordEntryPointInterceptor extends TraceInterceptorAdaptor
     @Resource
     protected DynamicFieldManager manager;
 
+    private static final Map<Object, String> consumerGroupIdMappings = new ConcurrentHashMap<Object, String>();
+
     @Override
     public String getPluginName() {
         return KafkaConstants.PLUGIN_NAME;
@@ -72,8 +73,6 @@ public class ConsumerRecordEntryPointInterceptor extends TraceInterceptorAdaptor
     public int getPluginType() {
         return KafkaConstants.PLUGIN_TYPE;
     }
-
-    private volatile String groupGlobal = null;
 
     /**
      * 是否是调用端
@@ -119,25 +118,13 @@ public class ConsumerRecordEntryPointInterceptor extends TraceInterceptorAdaptor
                 remoteAddress = sb.toString();
             }
         }
-        String group = null;
-        if (groupGlobal == null) {
-            if (args.length >= 3) {
-                group = manager.removeField(args[2], KafkaConstants.DYNAMIC_FIELD_GROUP);
-            }
+        String group = consumerGroupIdMappings.get(consumer);
+        if (group == null) {
+            group = extractGroup(args, consumer);
             if (group == null) {
-                try {
-                    Field groupId = ReflectUtil.getField(consumer, "groupId");
-                    group = (String) groupId.get(consumer);
-                } catch (Throwable e) {
-                    try {
-                        Object coordinator = Reflect.on(consumer).get(KafkaConstants.REFLECT_FIELD_COORDINATOR);
-                        group = ReflectUtil.reflectSlience(coordinator, KafkaConstants.REFLECT_FIELD_GROUP_ID);
-                    } catch (Exception exp) {
-                        LOGGER.warn("get kafka group id by reflection failed, using groupGlobal instead.", e);
-                    }
-                    groupGlobal = Thread.currentThread().getName().split("-")[0];
-                }
+                group = Thread.currentThread().getName().split("-")[0];
             }
+            consumerGroupIdMappings.put(consumer, group);
         }
 
         SpanRecord spanRecord = new SpanRecord();
@@ -149,9 +136,52 @@ public class ConsumerRecordEntryPointInterceptor extends TraceInterceptorAdaptor
         }
         spanRecord.setRequest(consumerRecord);
         spanRecord.setService(consumerRecord.topic());
-        spanRecord.setMethod(group == null ? groupGlobal : group);
+        spanRecord.setMethod(group);
         spanRecord.setCallbackMsg(consumerCell + "");
         return spanRecord;
+    }
+
+    private String extractGroup(Object[] args, Object obj) {
+        Object group = null;
+        if (args.length >= 3) {
+            group = manager.removeField(args[2], KafkaConstants.DYNAMIC_FIELD_GROUP);
+        }
+        if (group != null) {
+            return (String) group;
+        }
+
+        if (group == null) {
+            try {
+                Field groupId = ReflectUtil.getField(obj, "groupId");
+                group = groupId.get(obj);
+            } catch (Throwable e) {
+                try {
+                    Object coordinator = Reflect.on(obj).get(KafkaConstants.REFLECT_FIELD_COORDINATOR);
+                    group = ReflectUtil.reflectSlience(coordinator, KafkaConstants.REFLECT_FIELD_GROUP_ID);
+                } catch (Exception exp) {
+
+                }
+            }
+        }
+        if (group != null) {
+            return (String) group;
+        }
+
+        try {
+            Consumer consumer = (Consumer) obj;
+            Object proxy = Reflect.on(consumer).get("h");
+            Object advised = Reflect.on(proxy).get("advised");
+            Object targetSource = Reflect.on(advised).get("targetSource");
+            Object kafkaConsumer = Reflect.on(targetSource).get("target");
+            group = Reflect.on(kafkaConsumer).get("groupId");
+            if (group.getClass().getName().equals("java.util.Optional")) {
+                group = Reflect.on(group).call("get").get();
+            }
+            return (String) group;
+        } catch (Exception e) {
+            LOGGER.error("extract groupId from Spring-Kafka occur exception, using global group!", e);
+            return null;
+        }
     }
 
     @Override

--- a/instrument-modules/user-modules/module-apache-kafka/src/main/resources/README.md
+++ b/instrument-modules/user-modules/module-apache-kafka/src/main/resources/README.md
@@ -1,2 +1,2 @@
-2.0.0.8
-修复spring-kafka影子消息白名单等没配置，抛出error直接导致业务消费者下线问题
+2.0.0.9
+修复spring-kafka trace日志group丢失问题

--- a/instrument-modules/user-modules/module-apache-kafka/src/main/resources/module.config
+++ b/instrument-modules/user-modules/module-apache-kafka/src/main/resources/module.config
@@ -8,5 +8,5 @@ import-package=com.pamirs.pradar.*
 # dependency of module or swither,multi split with comma
 dependencies=pradar-core
 simulator-version=1.0.0-
-module-version=2.0.0.8
+module-version=2.0.0.9
 dependencies-info=pradar-core@2.0.0.0


### PR DESCRIPTION
测试结果数据：takeTime:2022-07-15 15:01:48,takeTime:99492 testClassName:com.shulie.agent.plugin.spring.kafka.test.SpringKafkaIT, projectName:spring-kafka, dependecies:org.springframework.kafka:spring-kafka:2.5.6.RELEASE, testItNum:4, successItNum:4, failedItNum:0, 
	success:
		testSendAsync0_normal: 业务异步发送 take time : 22532
		testSendAsync1_test: 影子异步发送 take time : 17756
		testSendSync0_normal: 业务同步发送 take time : 6139
		testSendSync1_test: 影子同步发送 take time : 10730
	failed:size=0
		
	trace:预计4 通过4

业务trace:
0100007f16578684908651015d122c0001|1657868490906|93fc707e-16ae-4913-8ba3-c0526bdd9f81|test|90458|192.168.63.36-94652|0.1|3|spring-kafka|41|kafka|kafka241_test_topic|highLevelGroup|00|ConsumerRecord[topic=kafka241_test_topic,partition=0,offset=407639,timestamp=1657868490886,timestampType=TimestampType[id=0,name=CreateTime,name=CREATE_TIME,ordinal=1],serializedKeySize=8,serializedValueSize=12,headers=RecordHeaders[headers={RecordHeader[key=p-pradar-userdata,value=tn@089c86319a3d50d2855a12260d133246@],RecordHeader[key=p-pradar-cluster-test,value=0],RecordHeader[key=p-pradar-traceid,value=0100007f16578684908651015d122c0001],RecordHeader[key=p-pradar-rpcid,value=0.1],RecordHeader[key=p-pradar-appname,value=spring-kafka],RecordHeader[key=p-pradar-upappname,value=spring-kafka],RecordHeader[key=p-pradar-reappname,value=spring-kafka],RecordHeader[key=p-pradar-remote-ip,value=192.168.63.36],RecordHeader[key=p-pradar-debug,value=0]},isReadOnly=false],key=syncSend,value=testsyncSend,leaderEpoch=Optional[value=0]]||false~false~false~true|19|#1|@spring-kafka~~|@spring-kafka~unknow~~0~0||@tn@089c86319a3d50d2855a12260d133246@|@@st99:org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1@nidempty@et99:org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1
	
影子trace:
0100007f16578684970141020d122c0001|1657868497234|93fc707e-16ae-4913-8ba3-c0526bdd9f81|test|90458|192.168.63.36-94652|0.1|3|spring-kafka|383|kafka|PT_kafka241_test_topic|PT_highLevelGroup|00|ConsumerRecord[topic=PT_kafka241_test_topic,partition=0,offset=423808,timestamp=1657868497034,timestampType=TimestampType[id=0,name=CreateTime,name=CREATE_TIME,ordinal=1],serializedKeySize=8,serializedValueSize=12,headers=RecordHeaders[headers={RecordHeader[key=p-pradar-cluster-test,value=true],RecordHeader[key=p-pradar-userdata,value=tn@089c86319a3d50d2855a12260d133246@],RecordHeader[key=p-pradar-cluster-test,value=1],RecordHeader[key=p-pradar-traceid,value=0100007f16578684970141020d122c0001],RecordHeader[key=p-pradar-rpcid,value=0.1],RecordHeader[key=p-pradar-appname,value=spring-kafka],RecordHeader[key=p-pradar-upappname,value=spring-kafka],RecordHeader[key=p-pradar-reappname,value=spring-kafka],RecordHeader[key=p-pradar-remote-ip,value=192.168.63.36],RecordHeader[key=p-pradar-debug,value=0]},isReadOnly=false],key=syncSend,value=testsyncSend,leaderEpoch=Optional[value=0]]||true~false~false~true|198|#1|@spring-kafka~~|@spring-kafka~unknow~~0~0||@tn@089c86319a3d50d2855a12260d133246@|@@st126:PT_kafka241_test_topichighLevelGroupConcurrentMessageListenerContainer-0-C-1@nidempty@et126:PT_kafka241_test_topichighLevelGroupConcurrentMessageListenerContainer-0-C-1