### PR TITLE
适配比较老的kafka版本0.11.0.0

### DIFF
--- a/instrument-modules/user-modules/module-alibaba-rocketmq/pom.xml
+++ b/instrument-modules/user-modules/module-alibaba-rocketmq/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.72</version>
+            <version>2.0.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instrument-modules/user-modules/module-apache-kafka/pom.xml
+++ b/instrument-modules/user-modules/module-apache-kafka/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <module-name>apache-kafka</module-name>
     </properties>
-    <version>2.0.0.9</version>
+    <version>2.0.0.10</version>
 
     <dependencies>
         <dependency>

--- a/instrument-modules/user-modules/module-apache-kafka/src/main/java/com/pamirs/attach/plugin/apache/kafka/origin/ConsumerProxy.java
+++ b/instrument-modules/user-modules/module-apache-kafka/src/main/java/com/pamirs/attach/plugin/apache/kafka/origin/ConsumerProxy.java
@@ -563,8 +563,11 @@ public class ConsumerProxy<K, V> implements Consumer<K, V> {
         }
 
         Object ptInterceptors = Reflect.on(kafkaConsumer).get("interceptors");
-        List list = Reflect.on(ptInterceptors).get("interceptors");
-        if (list == null || list.isEmpty()) {
+        List list = null;
+        if(Reflect.on(ptInterceptors).existsField("interceptors")){
+            list = Reflect.on(ptInterceptors).get("interceptors");
+        }
+        if ((list == null || list.isEmpty()) && interceptors != null) {
             log.info("set kafka biz interceptors to pt consumer:{}", interceptors);
             Reflect.on(kafkaConsumer).set("interceptors", interceptors);
         }

--- a/instrument-modules/user-modules/module-apache-kafka/src/main/resources/README.md
+++ b/instrument-modules/user-modules/module-apache-kafka/src/main/resources/README.md
@@ -1,2 +1,2 @@
-2.0.0.9
-修复spring-kafka trace日志group丢失问题
+2.0.0.10
+适配比较老的kafka版本0.11.0.0

--- a/instrument-modules/user-modules/module-apache-kafka/src/main/resources/module.config
+++ b/instrument-modules/user-modules/module-apache-kafka/src/main/resources/module.config
@@ -8,5 +8,5 @@ import-package=com.pamirs.pradar.*
 # dependency of module or swither,multi split with comma
 dependencies=pradar-core
 simulator-version=1.0.0-
-module-version=2.0.0.9
+module-version=2.0.0.10
 dependencies-info=pradar-core@2.0.0.0

--- a/instrument-modules/user-modules/module-command-channel/pom.xml
+++ b/instrument-modules/user-modules/module-command-channel/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.72</version>
+            <version>2.0.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/instrument-modules/user-modules/module-pradar-core/pom.xml
+++ b/instrument-modules/user-modules/module-pradar-core/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.72</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
takeTime:2022-07-25 17:12:45,takeTime:132969 testClassName:com.shulie.agent.plugin.kafka.KafkaHeaderDisableIT, projectName:kafka_client_220_consumer-test, dependecies:org.apache.kafka:kafka-clients:0.11.0.0, testItNum:8, successItNum:8, failedItNum:0, 
	success:
		testSendSync0_normal: auto_commit_topic业务同步发送 take time : 6543
		testSendSync1_test: auto_commit_topic影子同步发送 take time : 5204
		testSendSync2_normal: every_poll_commit_topic业务同步发送 take time : 5202
		testSendSync3_test: every_poll_commit_topic影子同步发送 take time : 5180
		testSendSync4_normal: every_poll_commit_topic2业务同步发送 take time : 5162
		testSendSync5_test: every_poll_commit_topic2影子同步发送 take time : 5188
		testSendSync6_normal: is_biz_first_topic业务同步发送 take time : 5181
		testSendSync7_test: is_biz_first_topic影子同步发送 take time : 5381
	failed:size=0
		
	trace:预计8 通过8



