### PR TITLE
[bugfix] 在使用caffeine时，代码中42行returnSet为空时，会导致返回的Object[]无法强转为Set，这里修改为…

### DIFF
--- a/instrument-modules/user-modules/module-caffeine/src/main/java/com/pamirs/attach/plugin/caffeine/interceptor/EntrySetInterceptor.java
+++ b/instrument-modules/user-modules/module-caffeine/src/main/java/com/pamirs/attach/plugin/caffeine/interceptor/EntrySetInterceptor.java
@@ -14,16 +14,16 @@
  */
 package com.pamirs.attach.plugin.caffeine.interceptor;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
 import com.pamirs.attach.plugin.caffeine.utils.WrapEntry;
 import com.pamirs.pradar.Pradar;
 import com.pamirs.pradar.cache.ClusterTestCacheWrapperKey;
 import com.pamirs.pradar.interceptor.ModificationInterceptorAdaptor;
 import com.shulie.instrument.simulator.api.listener.ext.Advice;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * @author jirenhe | jirenhe@shulie.io
@@ -39,7 +39,7 @@ public class EntrySetInterceptor extends ModificationInterceptorAdaptor {
         }
         Set<Map.Entry> returnSet = (Set<Entry>)returnObj;
         if (returnSet.size() == 0) {
-            return new Object[0];
+            return new HashSet(0);
         }
         Set<Map.Entry> resultSet = new HashSet();
         for (Entry entry : returnSet) {


### PR DESCRIPTION
【问题】接入agent后，在使用caffeine缓存组件时，当set为空时，会导致 [Ljava.lang.Object; cannot be cast to java.util.Set 对象转换异常。
【原因】根据debug,会发现module-caffeine中的EntrySetInterceptor类，在判断set为空时，会返回new Object[0]的对象。
[代码链接]( https://github.com/shulieTech/LinkAgent/blob/main/instrument-modules/user-modules/module-caffeine/src/main/java/com/pamirs/attach/plugin/caffeine/interceptor/EntrySetInterceptor.java) 第42行。

下面是 caffeine 的 BoundedLocalCache 的 entrySet()方法被增强后的反编译代码。
![image](https://user-images.githubusercontent.com/49027834/222403488-ebc5971f-45c2-4e8d-a225-4f6688fc920d.png)
当new Object[0] 强转为 Set时，会转换异常。
【简单实验】
public class CastTest {
    public static void main(String[] args) {
        Set<Map<String,String>> test = new HashSet<>();
        Set<Map<String,String>> t1 = (Set)getOb(test);
        System.out.println(JSON.toJSONString(t1));
    }
    public static Object getOb(Object o){
        Object a = new Object[0];;
        System.out.println(JSON.toJSONString(a));
        return a;
    }
}
![image](https://user-images.githubusercontent.com/49027834/222404235-7394a215-c755-4e74-8432-6cbff548b564.png)


 