### PR TITLE
[bugfix]由于PradarEventListener的order重复，导致ApplicationConfigHttpResolver 的白名单开启事件无法成功加入到 Listeners 中。导致全局白名单关闭再开启的情况下，agent 端白名单开关开启逻辑没有执行，导致白名单列表无法成功拉取。

### DIFF
--- a/instrument-modules/user-modules/module-pradar-config-fetcher/src/main/java/com/shulie/instrument/module/config/fetcher/config/resolver/http/ApplicationConfigHttpResolver.java
+++ b/instrument-modules/user-modules/module-pradar-config-fetcher/src/main/java/com/shulie/instrument/module/config/fetcher/config/resolver/http/ApplicationConfigHttpResolver.java
@@ -222,7 +222,7 @@ public class ApplicationConfigHttpResolver extends AbstractHttpResolver<Applicat
 
             @Override
             public int order() {
-                return 80;
+                return 9;
             }
         }).addListener(new PradarEventListener() {
             @Override
@@ -239,7 +239,7 @@ public class ApplicationConfigHttpResolver extends AbstractHttpResolver<Applicat
 
             @Override
             public int order() {
-                return 81;
+                return 12;
             }
         });
     }

--- a/instrument-modules/user-modules/module-pradar-config-fetcher/src/main/java/com/shulie/instrument/module/config/fetcher/config/resolver/http/ApplicationConfigHttpResolver.java
+++ b/instrument-modules/user-modules/module-pradar-config-fetcher/src/main/java/com/shulie/instrument/module/config/fetcher/config/resolver/http/ApplicationConfigHttpResolver.java
@@ -222,7 +222,7 @@ public class ApplicationConfigHttpResolver extends AbstractHttpResolver<Applicat
 
             @Override
             public int order() {
-                return 11;
+                return 29;
             }
         }).addListener(new PradarEventListener() {
             @Override

--- a/instrument-modules/user-modules/module-pradar-config-fetcher/src/main/java/com/shulie/instrument/module/config/fetcher/config/resolver/http/ApplicationConfigHttpResolver.java
+++ b/instrument-modules/user-modules/module-pradar-config-fetcher/src/main/java/com/shulie/instrument/module/config/fetcher/config/resolver/http/ApplicationConfigHttpResolver.java
@@ -222,7 +222,7 @@ public class ApplicationConfigHttpResolver extends AbstractHttpResolver<Applicat
 
             @Override
             public int order() {
-                return 29;
+                return 80;
             }
         }).addListener(new PradarEventListener() {
             @Override
@@ -239,7 +239,7 @@ public class ApplicationConfigHttpResolver extends AbstractHttpResolver<Applicat
 
             @Override
             public int order() {
-                return 12;
+                return 81;
             }
         });
     }

--- a/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/pressurement/agent/shared/service/EventRouter.java
+++ b/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/pressurement/agent/shared/service/EventRouter.java
@@ -137,11 +137,10 @@ public final class EventRouter {
     }
 
     // 目前已经使用的order: -1 0 6
-    // 数据源： 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
+    // 数据源：9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
     // mq:      30 31 32 33 34 60
     // es:      35 36 37
     // job:     50
-    // other:   80 81
     // 99
     private Set<PradarEventListener> listeners = new TreeSet<PradarEventListener>(new Comparator<PradarEventListener>() {
         @Override

--- a/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/pressurement/agent/shared/service/EventRouter.java
+++ b/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/pressurement/agent/shared/service/EventRouter.java
@@ -141,6 +141,7 @@ public final class EventRouter {
     // mq:      30 31 32 33 34 60
     // es:      35 36 37
     // job:     50
+    // other:   80 81
     // 99
     private Set<PradarEventListener> listeners = new TreeSet<PradarEventListener>(new Comparator<PradarEventListener>() {
         @Override


### PR DESCRIPTION
问题：全局白名单关闭再开启的情况下，agent 端白名单开关开启逻辑没有执行，导致白名单列表无法成功拉取。
原因：ApplicationConfigHttpResolver和ApacheHbasePlugin在注册listener时，order都设置为11，重复了，导致ApplicationConfigHttpResolver 的白名单开启事件无法成功加入到 Listeners 中。


![image](https://github.com/shulieTech/LinkAgent/assets/49027834/2827d272-91c1-4ece-ab11-7e883b0ae90d)

![image](https://github.com/shulieTech/LinkAgent/assets/49027834/6b214af4-6da0-40d2-920d-3c537eb76384)

![image](https://github.com/shulieTech/LinkAgent/assets/49027834/064ca738-01b9-4381-8c6d-309d47f79a2d)

![image](https://github.com/shulieTech/LinkAgent/assets/49027834/8822214c-27cd-4b06-a6fa-4620323ccebe)

![image](https://github.com/shulieTech/LinkAgent/assets/49027834/f3449c39-4d6d-4471-86f7-083fcfec5949)

把ApplicationConfigHttpResolver的开关开启listenr的order从11改为9。已检索过，9是没有使用的。

修改完成后，结果符合预期，关闭白名单全局开关，再打开开关，结果符合预期。
![image](https://github.com/shulieTech/LinkAgent/assets/49027834/43a55b52-ac6d-453e-8069-e671f9799bad)

![image](https://github.com/shulieTech/LinkAgent/assets/49027834/33edc62b-9746-4eae-93f2-b39e65387321)

