### PR TITLE
[modify] 修改 GlobalCacheBshScriptEvaluator 的 logger 对应的名字

### DIFF
--- a/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/script/bsh/GlobalCacheBshScriptEvaluator.java
+++ b/instrument-modules/user-modules/module-pradar-core/src/main/java/com/pamirs/pradar/script/bsh/GlobalCacheBshScriptEvaluator.java
@@ -1,32 +1,17 @@
 package com.pamirs.pradar.script.bsh;
 
-import bsh.EvalError;
 import bsh.Interpreter;
 import bsh.NameSpace;
 import com.pamirs.attach.plugin.dynamic.reflect.ReflectionUtils;
-import com.pamirs.pradar.internal.config.MockConfig;
-import com.pamirs.pradar.pressurement.agent.event.IEvent;
-import com.pamirs.pradar.pressurement.agent.event.impl.MockConfigAddEvent;
-import com.pamirs.pradar.pressurement.agent.event.impl.MockConfigModifyEvent;
-import com.pamirs.pradar.pressurement.agent.event.impl.MockConfigRemoveEvent;
-import com.pamirs.pradar.pressurement.agent.listener.EventResult;
-import com.pamirs.pradar.pressurement.agent.listener.PradarEventListener;
-import com.pamirs.pradar.pressurement.agent.shared.service.EventRouter;
-import com.pamirs.pradar.pressurement.agent.shared.service.GlobalConfig;
 import com.pamirs.pradar.script.ScriptEvaluator;
-import com.pamirs.pradar.script.commons.InterpreterWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.StringReader;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 public class GlobalCacheBshScriptEvaluator implements ScriptEvaluator {
 
-    private final static Logger logger = LoggerFactory.getLogger("ThreadLocalScriptEvaluator-LOGGER");
+    private final static Logger logger = LoggerFactory.getLogger("GlobalCacheBshScriptEvaluator-LOGGER");
 
     private ClassLoader classLoader;
 


### PR DESCRIPTION
<img width="1023" alt="image" src="https://github.com/shulieTech/LinkAgent/assets/49027834/98bdfbe9-c977-4b46-9ada-978b00901c9f">
GlobalCacheBshScriptEvaluator 日志的 name 使用了 ThreadLocalScriptEvaluator 的名字。应该为 GlobalCacheBshScriptEvaluator。